### PR TITLE
Scala version bumped up to 2.12.10.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.cisco.cognitive</groupId>
     <artifactId>oraf</artifactId>
-    <version>1.2.0</version>
+    <version>1.3.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -43,11 +43,10 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <encoding>UTF-8</encoding>
-        <scala.version>2.11.8</scala.version>
-        <scala.compat.version>2.11</scala.compat.version>
-        <scala.binary.version>2.11</scala.binary.version>
-        <spec2.version>4.2.0</spec2.version>
-        <project.depVersion>2.4.0</project.depVersion>
+        <scala.compat.version>2.12</scala.compat.version>
+        <scala.binary.version>2.12</scala.binary.version>
+        <scala.version>2.12.10</scala.version>
+        <spark.version>2.4.4</spark.version>
     </properties>
 
     <dependencies>
@@ -73,65 +72,65 @@
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_${scala.binary.version}</artifactId>
-            <version>${project.depVersion}</version>
+            <version>${spark.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_${scala.binary.version}</artifactId>
-            <version>${project.depVersion}</version>
+            <version>${spark.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-streaming_${scala.binary.version}</artifactId>
-            <version>${project.depVersion}</version>
+            <version>${spark.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_${scala.binary.version}</artifactId>
-            <version>${project.depVersion}</version>
+            <version>${spark.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-graphx_${scala.binary.version}</artifactId>
-            <version>${project.depVersion}</version>
+            <version>${spark.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-mllib-local_${scala.binary.version}</artifactId>
-            <version>${project.depVersion}</version>
+            <version>${spark.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-mllib-local_${scala.binary.version}</artifactId>
-            <version>${project.depVersion}</version>
+            <version>${spark.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-mllib_${scala.binary.version}</artifactId>
-            <version>${project.depVersion}</version>
+            <version>${spark.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-mllib_${scala.binary.version}</artifactId>
-            <version>${project.depVersion}</version>
+            <version>${spark.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_${scala.binary.version}</artifactId>
-            <version>${project.depVersion}</version>
+            <version>${spark.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
-            <version>${project.depVersion}</version>
+            <version>${spark.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
@@ -205,6 +204,7 @@
                             <args>
                                 <arg>-dependencyfile</arg>
                                 <arg>${project.build.directory}/.scala_dependencies</arg>
+                                <arg>-Ydelambdafy:inline</arg>
                             </args>
                         </configuration>
                     </execution>

--- a/src/main/scala/org/apache/spark/ml/tree/impl/OptimizedRandomForest.scala
+++ b/src/main/scala/org/apache/spark/ml/tree/impl/OptimizedRandomForest.scala
@@ -813,7 +813,7 @@ private[spark] object OptimizedRandomForest extends Logging {
 
         // transform nodeStatsAggregators array to (nodeIndex, nodeAggregateStats) pairs,
         // which can be combined with other partition using `reduceByKey`
-        val indexSeq :SeqView[(OptimizedDTStatsAggregator, Int),Array[(OptimizedDTStatsAggregator, Int)]] = nodeStatsAggregators.view.zipWithIndex
+        val indexSeq: SeqView[(OptimizedDTStatsAggregator, Int), Array[(OptimizedDTStatsAggregator, Int)]] = nodeStatsAggregators.view.zipWithIndex
         indexSeq.map(_.swap).iterator
       }
     }

--- a/src/main/scala/org/apache/spark/ml/tree/impl/OptimizedRandomForest.scala
+++ b/src/main/scala/org/apache/spark/ml/tree/impl/OptimizedRandomForest.scala
@@ -794,7 +794,8 @@ private[spark] object OptimizedRandomForest extends Logging {
 
         // transform nodeStatsAggregators array to (nodeIndex, nodeAggregateStats) pairs,
         // which can be combined with other partition using `reduceByKey`
-        nodeStatsAggregators.view.zipWithIndex.map(_.swap).iterator
+        val indexSeq: SeqView[(OptimizedDTStatsAggregator, Int), Array[(OptimizedDTStatsAggregator, Int)]] = nodeStatsAggregators.view.zipWithIndex
+        indexSeq.map(_.swap).iterator
       }
     } else {
       input.mapPartitions { points =>
@@ -812,7 +813,8 @@ private[spark] object OptimizedRandomForest extends Logging {
 
         // transform nodeStatsAggregators array to (nodeIndex, nodeAggregateStats) pairs,
         // which can be combined with other partition using `reduceByKey`
-        nodeStatsAggregators.view.zipWithIndex.map(_.swap).iterator
+        val indexSeq :SeqView[(OptimizedDTStatsAggregator, Int),Array[(OptimizedDTStatsAggregator, Int)]] = nodeStatsAggregators.view.zipWithIndex
+        indexSeq.map(_.swap).iterator
       }
     }
 


### PR DESCRIPTION
Added the following ``scalac`` option in order to be able to generate serialisable lambdas (see https://docs.google.com/document/d/1fbkjEL878witxVQpOCbjlvOvadHtVjYXeB-2mgzDTvk/edit#) for an explanation: ``-Ydelambdafy:inline``